### PR TITLE
Tomaszaba/issue37

### DIFF
--- a/R/module-data-wrangling.R
+++ b/R/module-data-wrangling.R
@@ -193,13 +193,18 @@ module_server_wrangling <- function(id, data) {
 
                 data() |>
                   dplyr::mutate(
-                    muac = mwana::recode_muac(x = !!rlang::sym(input$muac), .to = "cm")
-                  ) |>
-                  dplyr::rename(
-                    age = !!rlang::sym(input$age),
+                    muac = mwana::recode_muac(!!rlang::sym(input$muac), "cm"),
+                    dos = as.Date(!!rlang::sym(input$dos), format = "%d/%m/%Y"),
+                    dob = as.Date(!!rlang::sym(input$dob), format = "%d/%m/%Y"),
+                    age = as.numeric(!!rlang::sym(input$age)),
                     sex = !!rlang::sym(input$sex)
                   ) |>
-                  mwana::mw_wrangle_age(dos = NULL, dob = NULL, age = .data$age) |>
+                  mwana::mw_wrangle_age(
+                    dos = .data$dos, 
+                    dob = .data$dob, 
+                    age = .data$age,
+                    .decimals = 2
+                  ) |>
                   mwana::mw_wrangle_muac(
                     sex = .data$sex,
                     .recode_sex = TRUE,
@@ -259,7 +264,7 @@ module_server_wrangling <- function(id, data) {
                   )
               }
             )
-
+print(w)
             dataset$wrangled <- w
           },
           error = function(e) {

--- a/R/module-data-wrangling.R
+++ b/R/module-data-wrangling.R
@@ -239,10 +239,10 @@ module_server_wrangling <- function(id, data) {
 
                 data() |>
                   dplyr::mutate(
-                    muac = mwana::recode_muac(x = !!rlang::sym(input$muac), .to = "cm")
-                  ) |>
-                  dplyr::rename(
-                    age = !!rlang::sym(input$age),
+                    muac = mwana::recode_muac(!!rlang::sym(input$muac), "cm"),
+                    dos = as.Date(!!rlang::sym(input$dos), format = "%d/%m/%Y"),
+                    dob = as.Date(!!rlang::sym(input$dob), format = "%d/%m/%Y"),
+                    age = as.numeric(!!rlang::sym(input$age)),
                     sex = !!rlang::sym(input$sex),
                     weight = !!rlang::sym(input$weight),
                     height = !!rlang::sym(input$height)
@@ -253,7 +253,7 @@ module_server_wrangling <- function(id, data) {
                     weight = .data$weight,
                     height = .data$height
                   ) |>
-                  mwana::mw_wrangle_age(dos = NULL, dob = NULL, age = .data$age) |>
+                  mwana::mw_wrangle_age(.data$dos, .data$dob, .data$age) |>
                   mwana::mw_wrangle_muac(
                     sex = .data$sex,
                     .recode_sex = FALSE,

--- a/R/module-data-wrangling.R
+++ b/R/module-data-wrangling.R
@@ -175,12 +175,32 @@ module_server_wrangling <- function(id, data) {
             w <- switch(EXPR = input$wrangle,
               "wfhz" = {
                 shiny::req(input$sex, input$weight, input$height)
-                data() |>
-                  dplyr::rename(
+
+                ### Wrangle age dynamically ----
+                df <- if (nzchar(input$dos)) {
+                  dplyr::mutate(
+                    .data = data(),
+                    dos = as.Date(!!rlang::sym(input$dos), format = "%d/%m/%Y"),
+                    dob = as.Date(!!rlang::sym(input$dob), format = "%d/%m/%Y"),
+                    age = as.numeric(!!rlang::sym(input$age)),
                     sex = !!rlang::sym(input$sex),
                     weight = !!rlang::sym(input$weight),
                     height = !!rlang::sym(input$height)
                   ) |>
+                    mwana::mw_wrangle_age(.data$dos, .data$dob, .data$age)
+                } else {
+                  dplyr::mutate(
+                    .data = data(), 
+                    dos = NULL, 
+                    dob = NULL,
+                    sex = !!rlang::sym(input$sex),
+                    weight = !!rlang::sym(input$weight),
+                    height = !!rlang::sym(input$height)
+                  )
+                }
+
+                 ### Wrangle WFHZ data ----
+                df |>
                   mwana::mw_wrangle_wfhz(
                     sex = .data$sex,
                     .recode_sex = TRUE,
@@ -188,23 +208,34 @@ module_server_wrangling <- function(id, data) {
                     height = .data$height
                   )
               },
+
               "mfaz" = {
                 shiny::req(input$age, input$sex, input$muac)
 
-                data() |>
+                ### Wrangle age dynamically ----
+                df <- if (nzchar(input$dos)) {
                   dplyr::mutate(
+                    .data = data(),
                     muac = mwana::recode_muac(!!rlang::sym(input$muac), "cm"),
                     dos = as.Date(!!rlang::sym(input$dos), format = "%d/%m/%Y"),
                     dob = as.Date(!!rlang::sym(input$dob), format = "%d/%m/%Y"),
                     age = as.numeric(!!rlang::sym(input$age)),
                     sex = !!rlang::sym(input$sex)
                   ) |>
-                  mwana::mw_wrangle_age(
-                    dos = .data$dos, 
-                    dob = .data$dob, 
-                    age = .data$age,
-                    .decimals = 2
+                    mwana::mw_wrangle_age(.data$dos, .data$dob, .data$age)
+                } else {
+                  dplyr::mutate(
+                    .data = data(),
+                    muac = mwana::recode_muac(!!rlang::sym(input$muac), "cm"),
+                    dos = NULL,
+                    dob = NULL,
+                    sex = !!rlang::sym(input$sex)
                   ) |>
+                    mwana::mw_wrangle_age(NULL, NULL, .data$age)
+                }
+
+                ### Wrangle MUAC ----
+                df |>
                   mwana::mw_wrangle_muac(
                     sex = .data$sex,
                     .recode_sex = TRUE,
@@ -237,8 +268,10 @@ module_server_wrangling <- function(id, data) {
                   input$muac
                 )
 
-                data() |>
+                ### Wrangle age dynamically ----
+                df <- if (nzchar(input$dos)) {
                   dplyr::mutate(
+                    .data = data(),
                     muac = mwana::recode_muac(!!rlang::sym(input$muac), "cm"),
                     dos = as.Date(!!rlang::sym(input$dos), format = "%d/%m/%Y"),
                     dob = as.Date(!!rlang::sym(input$dob), format = "%d/%m/%Y"),
@@ -247,13 +280,28 @@ module_server_wrangling <- function(id, data) {
                     weight = !!rlang::sym(input$weight),
                     height = !!rlang::sym(input$height)
                   ) |>
+                    mwana::mw_wrangle_age(.data$dos, .data$dob, .data$age)
+                } else {
+                  dplyr::mutate(
+                    .data = data(),
+                    muac = mwana::recode_muac(!!rlang::sym(input$muac), "cm"),
+                    dos = NULL,
+                    dob = NULL,
+                    sex = !!rlang::sym(input$sex),
+                    weight = !!rlang::sym(input$weight),
+                    height = !!rlang::sym(input$height)
+                  ) |>
+                    mwana::mw_wrangle_age(NULL, NULL, .data$age)
+                }
+
+                ### Wrangle WHZ and MUAC data ----
+                df |>
                   mwana::mw_wrangle_wfhz(
                     sex = .data$sex,
                     .recode_sex = TRUE,
                     weight = .data$weight,
                     height = .data$height
                   ) |>
-                  mwana::mw_wrangle_age(.data$dos, .data$dob, .data$age) |>
                   mwana::mw_wrangle_muac(
                     sex = .data$sex,
                     .recode_sex = FALSE,
@@ -264,7 +312,7 @@ module_server_wrangling <- function(id, data) {
                   )
               }
             )
-print(w)
+
             dataset$wrangled <- w
           },
           error = function(e) {


### PR DESCRIPTION
Address #37. Henceforth, users can upload input data with date of data collection (dos) and child's birthdate (dob) and let the app calculate the age in months from it. 

To do that, column holding "dos" must be renamed to dos; column holding "dob" must be renamed to dob. Accepted date format is dd/mm/YYYY. Example: 12/03/2026. 

In addition, there should also be a column named "age" wherein age in months - from dos and dob - will be filled into. This can be an empty column, or a mixture - when calendar of events is used to estimate age in month. 